### PR TITLE
Add support for absolutely positioning the anchor for a crop operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ There are a number of options out there, but differentiates itself by:
   level of control to enable using the right tool for the given operation. Bugs,
   features, performance are a few of the factors that may influence this.
 * Friendly CLI to create your web server. No custom app required.
-* Good *Nix & Windows support. 
+* Good *Nix & Windows support.
 * Device centric responses, where more than a URI may influence response.
   Compression and Accepts header (i.e. WebP) being examples.
 
@@ -270,7 +270,7 @@ Example URI using [Default Options](#router-options):
   `some/image/path/:/cmd1=param1:val,param2:val,param3noVal/cmd2NoParams?cache=false`
 
 Or a more real-world example:  
-  
+
   `/my-s3-bucket/big-image.jpg/:/rs=w:640/cr=w:90%25,h:90%25`
 
 See [Things to Try](#things-to-try) for many more examples.
@@ -324,6 +324,12 @@ Arguments:
   and Left are applied from the anchor. Possible horizontal axis
   values include left (l), center (c), and right (r). Possible vertical axis
   values include top (t), center (c), and bottom (b).
+* Anchor Y (`ay`, default: `50%`) - Can be used to absolutely position the
+  anchor offset vertically using either percentage or pixel values. Also supports offsets
+  relative to the Anchor value.
+* Anchor X (`ax`, default: `50%`) - Can be used to absolutely position the
+  anchor offset horizontally using either percentage or pixel values. Also supports offsets
+  relative to the Anchor value.
 
 ### Examples
 
@@ -331,6 +337,12 @@ Arguments:
 2. `cr=w:64,h:64,a:cc` - Crop 64x64 anchored from center.
 3. `cr=l:10,w:64,h:64` - Crops 64x64 from the left at 10px (ignoring the horizontal
    axis value of `c`), and vertically anchors from center since top is not provided.
+4. `cr=w:64,h:64,ax:30%25,ay:70%25` - Crops 64x64 anchored (centered) 30% from the left edge of the
+   image and 70% from the top edge of the image.
+5. `cr=w:64,h:64,ax:100,ay:200` - Crops 64x64 anchored (centered) 100 pixels from the left edge
+   of the image and 200 pixels from the top edge of the image.
+6. `cr=w:64,h:64,a:br,ax:-20%,ay:-30%` - Crops 64x64 anchored 20% from the right edge and 30% from
+   the bottom of the image.
 
 
 ## Gamma (gm)
@@ -360,7 +372,7 @@ Arguments:
   Do not use in conjunction with Hex color.
 * Green (`g`) - Green component of the RGB(A) spectrum.
   An integer between 0 and 255.
-  Do not use in conjunction with Hex color. 
+  Do not use in conjunction with Hex color.
 * Blue (`b`) - Blue component of the RGB(A) spectrum.
   An integer between 0 and 255.
   Do not use in conjunction with Hex color.
@@ -408,7 +420,7 @@ Arguments:
 
 ## Quality (qt)
 
-The output quality to use for lossy JPEG, WebP and TIFF output formats. 
+The output quality to use for lossy JPEG, WebP and TIFF output formats.
 
 * Quality (`q`, default: `80`) - Value between 1 (worst, smallest) and
   100 (best, largest).  
@@ -471,9 +483,9 @@ Arguments:
 
 ### Examples
 
-1. `fx-sp=r:3,f:5,j:5` - 
- 
- 
+1. `fx-sp=r:3,f:5,j:5` -
+
+
 ## Blur (fx-bl)
 
 Fast mild blur by default, but can override the default sigma for more

--- a/lib/helpers/dimension.js
+++ b/lib/helpers/dimension.js
@@ -118,6 +118,42 @@ function resolveStep(originalImage, imageStep) {
       }
     }
   }
+
+  var hasAnchor = typeof imageStep.anchor === 'string',
+      hasAnchorX = typeof imageStep.anchorX === 'string',
+      hasAnchorY = typeof imageStep.anchorY === 'string';
+
+  if (hasAnchor || hasAnchorX || hasAnchorY) {
+    var anchorCenter = convertAnchorCenter(imageStep, originalImage);
+
+    if (hasAnchorX) {
+      info = getInfo(imageStep.anchorX);
+      var anchorXPixels = info.unit === '%' ? Math.floor(originalImage.info.width * info.value / 100) : info.value;
+      if (info.modifier === '+') {
+        imageStep.anchorX = anchorCenter.x + anchorXPixels;
+      } else if (info.modifier === '-') {
+        imageStep.anchorX = anchorCenter.x - anchorXPixels;
+      } else {
+        imageStep.anchorX = anchorXPixels;
+      }
+    } else {
+      imageStep.anchorX = anchorCenter.x;
+    }
+
+    if (hasAnchorY) {
+      info = getInfo(imageStep.anchorY);
+      var anchorYPixels = info.unit === '%' ? Math.floor(originalImage.info.height * info.value / 100) : info.value;
+      if (info.modifier === '+') {
+        imageStep.anchorY = anchorCenter.y + anchorYPixels;
+      } else if (info.modifier === '-') {
+        imageStep.anchorY = anchorCenter.y - anchorYPixels;
+      } else {
+        imageStep.anchorY = anchorYPixels;
+      }
+    } else {
+      imageStep.anchorY = anchorCenter.y;
+    }
+  }
 }
 
 function getInfo(value) {
@@ -138,4 +174,37 @@ function getXAspect(image) {
 
 function getYAspect(image) {
   return image.info.height / image.info.width;
+}
+
+function convertAnchorCenter(imageStep, originalImage) {
+  var anchor = typeof imageStep.anchor === 'string' && imageStep.anchor.length === 2 ? imageStep.anchor : 'cc',
+      convertedAnchor = { x: 0, y: 0 },
+      height = imageStep.height || originalImage.info.height,
+      width = imageStep.width || originalImage.info.width;
+
+  switch (anchor[0]) {
+    case 't':
+      convertedAnchor.y = Math.floor(height / 2);
+      break;
+    case 'b':
+      convertedAnchor.y = Math.floor(originalImage.info.height - (height / 2));
+      break;
+    default:
+      convertedAnchor.y = Math.floor(originalImage.info.height / 2);
+      break;
+  }
+
+  switch (anchor[1]) {
+    case 'l':
+      convertedAnchor.x = Math.floor(width / 2);
+      break;
+    case 'r':
+      convertedAnchor.x = Math.floor(originalImage.info.width - (width / 2));
+      break;
+    default:
+      convertedAnchor.x = Math.floor(originalImage.info.width / 2);
+      break;
+  }
+
+  return convertedAnchor;
 }

--- a/lib/processor/steps/crop.js
+++ b/lib/processor/steps/crop.js
@@ -1,58 +1,33 @@
 var helpers = require('../../helpers');
+var _ = require('lodash');
 
 module.exports = function(context, stepInfo) {
   var img = context.processedImage;
   helpers.dimension.resolveStep(img, stepInfo);
-
-  var anchorX = stepInfo.anchor && stepInfo.anchor.length === 2 && stepInfo.anchor[1];
-  var anchorY = stepInfo.anchor && stepInfo.anchor.length === 2 && stepInfo.anchor[0];
-
-  if (isNaN(stepInfo.top)) {
-    stepInfo.top = 0;
-  } else {
-    anchorY = 't'; // implied
-  }
-
-  if (isNaN(stepInfo.left)) {
-    stepInfo.left = 0;
-  } else {
-    anchorX = 'l'; // implied
-  }
+  var anchorX = isNaN(stepInfo.anchorX) ? Math.floor(img.info.width / 2) : stepInfo.anchorX,
+      anchorY = isNaN(stepInfo.anchorY) ? Math.floor(img.info.height / 2) : stepInfo.anchorY;
 
   if (isNaN(stepInfo.width)) {
-    stepInfo.width = img.info.width - stepInfo.left;
+    stepInfo.width = img.info.width - (stepInfo.left || 0);
   }
 
   if (isNaN(stepInfo.height)) {
-    stepInfo.height = img.info.height - stepInfo.top;
+    stepInfo.height = img.info.height - (stepInfo.top || 0);
   }
 
-  switch (anchorY) {
-    case 't': // top
-      // do nothing
-      break;
-    case 'b': // bottom
-      stepInfo.top = img.info.height - stepInfo.height - stepInfo.top;
-      break;
-    default: // center
-      stepInfo.top = Math.round((img.info.height - stepInfo.height - stepInfo.top) / 2);
-      break;
+  if (isNaN(stepInfo.top)) {
+    stepInfo.top = Math.round(anchorY - stepInfo.height / 2);
   }
 
-  switch (anchorX) {
-    case 'l': // left
-      // do nothing
-      break;
-    case 'r': // right
-      stepInfo.left = img.info.width - stepInfo.width - stepInfo.left;
-      break;
-    default: // center
-      stepInfo.left = Math.round((img.info.width - stepInfo.width - stepInfo.left) / 2);
-      break;
+  if (isNaN(stepInfo.left)) {
+    stepInfo.left = Math.round(anchorX - stepInfo.width / 2);
   }
 
   if (stepInfo.left < 0) {
     stepInfo.left = 0;
+  }
+  if ((stepInfo.left + stepInfo.width) > img.info.width) {
+    stepInfo.left = Math.max(0, img.info.width - stepInfo.width);
   }
   if ((stepInfo.left + stepInfo.width) > img.info.width) {
     // cap width
@@ -63,12 +38,14 @@ module.exports = function(context, stepInfo) {
     stepInfo.top = 0;
   }
   if ((stepInfo.top + stepInfo.height) > img.info.height) {
+    stepInfo.top = Math.max(0, img.info.height - stepInfo.height);
+  }
+  if ((stepInfo.top + stepInfo.height) > img.info.height) {
     // cap height
     stepInfo.height = img.info.height - stepInfo.top;
   }
-  context.sharp
-    .extract(stepInfo)
-  ;
+
+  context.sharp.extract(_.pick(stepInfo, ['top', 'left', 'width', 'height']));
 
   // track new dimensions for followup operations
   img.info.width = stepInfo.width;

--- a/lib/router/router-defaults.js
+++ b/lib/router/router-defaults.js
@@ -29,7 +29,9 @@ module.exports = {
       l: 'left',
       w: 'width',
       h: 'height',
-      a: 'anchor'
+      a: 'anchor',
+      ax: 'anchorX',
+      ay: 'anchorY'
     },
     /*fm: {
       name: 'format',

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "mocha": "^2.5.3",
     "mocha-istanbul": "^0.3.0",
     "open": "0.0.5",
-    "should": "^10.0.0"
+    "should": "^10.0.0",
+    "sinon": "^1.17.6",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/test/crop.tests.js
+++ b/test/crop.tests.js
@@ -1,0 +1,199 @@
+'use strict';
+
+var chai = require('chai');
+var expect = chai.expect;
+var crop = require('../lib/processor/steps/crop');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+
+describe('#Crop step', function () {
+  it('should correctly convert absolute percentage anchor positioning to pixel offsets', function () {
+    var context = {
+      sharp: {
+        extract: sinon.spy()
+      },
+      processedImage: {
+        info: {
+          width: 1000,
+          height: 500
+        }
+      }
+    };
+    var stepInfo = {
+      anchorY: '70%',
+      anchorX: '70%',
+      width: 500,
+      height: 250
+    };
+    crop(context, stepInfo);
+    expect(context.sharp.extract).to.have.been.calledWith({
+      left: 450,
+      top: 225,
+      width: 500,
+      height: 250
+    });
+  });
+
+  it('should correctly compute crop position when using absolute pixel anchor positioning', function () {
+    var context = {
+      sharp: {
+        extract: sinon.spy()
+      },
+      processedImage: {
+        info: {
+          width: 1000,
+          height: 500
+        }
+      }
+    };
+    var stepInfo = {
+      anchorY: '300',
+      anchorX: '750',
+      width: 500,
+      height: 250
+    };
+    crop(context, stepInfo);
+    expect(context.sharp.extract).to.have.been.calledWith({
+      left: 500,
+      top: 175,
+      width: 500,
+      height: 250
+    });
+  });
+
+  it('should correctly compute crop position when using absolute pixel anchor positioning with \'px\'', function () {
+    var context = {
+      sharp: {
+        extract: sinon.spy()
+      },
+      processedImage: {
+        info: {
+          width: 1000,
+          height: 500
+        }
+      }
+    };
+    var stepInfo = {
+      anchorY: '300px',
+      anchorX: '750px',
+      width: 500,
+      height: 250
+    };
+    crop(context, stepInfo);
+    expect(context.sharp.extract).to.have.been.calledWith({
+      left: 500,
+      top: 175,
+      width: 500,
+      height: 250
+    });
+  });
+
+  it('should prevent negative top/left positioning when using absolute anchor position', function () {
+    var context = {
+      sharp: {
+        extract: sinon.spy()
+      },
+      processedImage: {
+        info: {
+          width: 1000,
+          height: 500
+        }
+      }
+    };
+    var stepInfo = {
+      anchorY: '50',
+      anchorX: '50',
+      width: 500,
+      height: 250
+    };
+    crop(context, stepInfo);
+    expect(context.sharp.extract).to.have.been.calledWith({
+      left: 0,
+      top: 0,
+      width: 500,
+      height: 250
+    });
+  });
+
+  it('should restrict crop region to the image bounds when using large anchor values', function () {
+    var context = {
+      sharp: {
+        extract: sinon.spy()
+      },
+      processedImage: {
+        info: {
+          width: 1000,
+          height: 500
+        }
+      }
+    };
+    var stepInfo = {
+      anchorY: '450',
+      anchorX: '900',
+      width: 500,
+      height: 250
+    };
+    crop(context, stepInfo);
+    expect(context.sharp.extract).to.have.been.calledWith({
+      left: 500,
+      top: 250,
+      width: 500,
+      height: 250
+    });
+  });
+
+  it('should shrink the crop region if it exceeds the image size', function () {
+    var context = {
+      sharp: {
+        extract: sinon.spy()
+      },
+      processedImage: {
+        info: {
+          width: 1000,
+          height: 500
+        }
+      }
+    };
+    var stepInfo = {
+      anchorY: '450',
+      anchorX: '900',
+      width: 1100,
+      height: 600
+    };
+    crop(context, stepInfo);
+    expect(context.sharp.extract).to.have.been.calledWith({
+      left: 0,
+      top: 0,
+      width: 1000,
+      height: 500
+    });
+  });
+
+  it('should correctly handle cropping when specifying an anchor quadrant', function () {
+    var context = {
+      sharp: {
+        extract: sinon.spy()
+      },
+      processedImage: {
+        info: {
+          width: 1000,
+          height: 500
+        }
+      }
+    };
+    var stepInfo = {
+      anchor: 'br',
+      width: 200,
+      height: 100
+    };
+    crop(context, stepInfo);
+    expect(context.sharp.extract).to.have.been.calledWith({
+      left: 800,
+      top: 400,
+      width: 200,
+      height: 100
+    });
+  });
+});

--- a/test/dimension.tests.js
+++ b/test/dimension.tests.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var chai = require('chai');
+var _ = require('lodash');
 var expect = chai.expect;
 var dimension = require('../lib/helpers/dimension');
 
@@ -68,6 +69,156 @@ describe('#Dimension utilities', function () {
         left: 1000,
         width: 450,
         height: 5
+      });
+    });
+
+    describe('with anchor position specified', function () {
+      var originalImage = {
+        info: {
+          width: 2000,
+          height: 1000
+        }
+      };
+
+      it('should handle percentage values', function () {
+        var imageStep = {
+          width: '200',
+          height: '100',
+          anchorX: '30%',
+          anchorY: '70%'
+        };
+        dimension.resolveStep(originalImage, imageStep);
+        expect(imageStep).to.deep.equal({
+          width: 200,
+          height: 100,
+          anchorX: 600,
+          anchorY: 700
+        });
+      });
+
+      it('should handle pixel values', function () {
+        var imageStep = {
+          width: '200',
+          height: '100',
+          anchorX: '300px',
+          anchorY: '500px'
+        };
+        dimension.resolveStep(originalImage, imageStep);
+        expect(imageStep).to.deep.equal({
+          width: 200,
+          height: 100,
+          anchorX: 300,
+          anchorY: 500
+        });
+      });
+
+      it('should handle positive percentage offset values with no anchor specified', function () {
+        var imageStep = {
+          width: '200',
+          height: '100',
+          anchorX: '+10%',
+          anchorY: '+20%'
+        };
+        dimension.resolveStep(originalImage, imageStep);
+        expect(imageStep).to.deep.equal({
+          width: 200,
+          height: 100,
+          anchorX: 1200,
+          anchorY: 700
+        });
+      });
+
+      it('should handle positive pixel offset values with no anchor specified', function () {
+        var imageStep = {
+          width: '200',
+          height: '100',
+          anchorX: '+100px',
+          anchorY: '+200px'
+        };
+        dimension.resolveStep(originalImage, imageStep);
+        expect(imageStep).to.deep.equal({
+          width: 200,
+          height: 100,
+          anchorX: 1100,
+          anchorY: 700
+        });
+      });
+
+      it('should handle negative percentage offset values with no anchor specified', function () {
+        var imageStep = {
+          width: '200',
+          height: '100',
+          anchorX: '-10%',
+          anchorY: '-25%'
+        };
+        dimension.resolveStep(originalImage, imageStep);
+        expect(imageStep).to.deep.equal({
+          width: 200,
+          height: 100,
+          anchorX: 800,
+          anchorY: 250
+        });
+      });
+
+      it('should handle negative pixel offset values with no anchor specified', function () {
+        var imageStep = {
+          width: '200',
+          height: '100',
+          anchorX: '-100px',
+          anchorY: '-200px'
+        };
+        dimension.resolveStep(originalImage, imageStep);
+        expect(imageStep).to.deep.equal({
+          width: 200,
+          height: 100,
+          anchorX: 900,
+          anchorY: 300
+        });
+      });
+
+      it('should handle offset values with anchor specified', function () {
+        var imageStep, defaults = {
+          width: '200',
+          height: '100',
+          anchorX: '+10%',
+          anchorY: '+25%'
+        };
+        imageStep = _.assign({}, defaults, { anchor: 'bl', anchorY: '-25%' });
+        dimension.resolveStep(originalImage, imageStep);
+        expect(imageStep).to.deep.equal({
+          width: 200,
+          height: 100,
+          anchorX: 300,
+          anchorY: 700,
+          anchor: 'bl'
+        });
+        imageStep = _.assign({}, defaults, { anchor: 'tr', anchorX: '-10%' });
+        dimension.resolveStep(originalImage, imageStep);
+        expect(imageStep).to.deep.equal({
+          width: 200,
+          height: 100,
+          anchorX: 1700,
+          anchorY: 300,
+          anchor: 'tr'
+        });
+        imageStep = _.assign({}, defaults, { anchor: 'bc', anchorY: '-25%' });
+        dimension.resolveStep(originalImage, imageStep);
+        expect(imageStep).to.deep.equal({
+          width: 200,
+          height: 100,
+          anchorX: 1200,
+          anchorY: 700,
+          anchor: 'bc'
+        });
+        imageStep = _.assign({}, defaults, { anchor: 'cr', anchorX: '-400px' });
+        dimension.resolveStep(originalImage, imageStep);
+        expect(imageStep).to.deep.equal({
+          width: 200,
+          height: 100,
+          anchorX: 1500,
+          anchorY: 750,
+          anchor: 'cr'
+        });
       });
     });
   });

--- a/test/image-server.etags.json
+++ b/test/image-server.etags.json
@@ -68,5 +68,6 @@
 	"http://localhost:13337/Portrait_5.jpg/:/rs=w:320?cache=false": "3340085419",
 	"http://localhost:13337/Portrait_6.jpg/:/rs=w:320?cache=false": "2612685063",
 	"http://localhost:13337/Portrait_7.jpg/:/rs=w:320?cache=false": "783772049",
-	"http://localhost:13337/Portrait_8.jpg/:/rs=w:320?cache=false": "4137304836"
+	"http://localhost:13337/Portrait_8.jpg/:/rs=w:320?cache=false": "4137304836",
+	"http://localhost:13337/UP_steam_loco.jpg/:/cr=w:50%25,h:50%25,ay:500,ax:300/fm=f:jpeg?cache=false": "3441566768"
 }

--- a/test/image-server.requests.js
+++ b/test/image-server.requests.js
@@ -12,6 +12,7 @@ module.exports = [
   { steps: 'cr=l:50,t:50', label: 'crop left and top using default width/height' },
   { steps: 'cr=w:50%25,h:50%25,a:tl', label: 'crop to 50% anchored from top/left' },
   { steps: 'cr=w:50%25,h:50%25,a:br', label: 'crop to 50% anchored from bottom/right' },
+  { steps: 'cr=w:50%25,h:50%25,ay:500,ax:300', label: 'crop to 50% with pixel anchor positioning' },
   { steps: 'qt=q:20', label: 'apply low quality' },
   { steps: 'cp=c:1/fm=f:png', label: 'output png and use compression', contentType: 'image/png' },
   { steps: 'cp=c:2/pg/fm=f:png', label: 'output png with compression and progressive rendering', contentType: 'image/png' },


### PR DESCRIPTION
This adds support for specifying `ay` and `ax` for anchorY and anchorX during a crop operation. Cropping is thus more flexible than limiting it to the currently supported 9 quadrants (tl, tc, tr, cl, cc, cr, bl, bc, br).