### PR TITLE
Bump xxhash to remove warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "optimist": "0.6.1",
     "semaphore": "1.0.5",
     "sharp": "0.16.0",
-    "xxhash": "0.2.3"
+    "xxhash": "0.2.4"
   },
   "devDependencies": {
     "browser-launcher": "^1.0.0",


### PR DESCRIPTION
This bumps xxhash to remove the v8 warnings.

https://github.com/mscdex/node-xxhash/issues/11