### PR TITLE
Fix Vary header

### DIFF
--- a/lib/http/connect.js
+++ b/lib/http/connect.js
@@ -358,7 +358,7 @@ p.getHandler = function() {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Request-Method': 'GET',
         'Access-Control-Max-Age': '864000', // 10 days
-        'Vary': 'Accept; Accept-Encoding',
+        'Vary': 'Accept, Accept-Encoding',
         'Cache-Control': 'public,max-age=31536000',
         'Content-Length': (results.gzipAsset && results.gzipAsset.length) || image.buffer.length,
         'Content-Type': reqInfo.contentType || image.contentType


### PR DESCRIPTION
The `Vary` header is incorrectly listing values separated by semi-colons. They are supposed to be comma-separated. This seems to be breaking Akamai's ability to cache.