### PR TITLE
corrupted file in cache cause uncatch exception

### DIFF
--- a/lib/storage/fs/index.js
+++ b/lib/storage/fs/index.js
@@ -25,7 +25,7 @@ p.fetch = function(options, originalPath, stepsHash, cb) {
       try {
         info = _.merge(info, JSON.parse(data.toString()));
       catch (err) {
-        cb(err);
+        return cb(err);
       }
     }
 

--- a/lib/storage/fs/index.js
+++ b/lib/storage/fs/index.js
@@ -22,7 +22,11 @@ p.fetch = function(options, originalPath, stepsHash, cb) {
   fs.readFile(filename + '.json', 'utf8', function(err, data) {
     var info = { path: originalPath, stepsHash: stepsHash };
     if (data) {
-      info = _.merge(info, JSON.parse(data.toString()));
+      try {
+        info = _.merge(info, JSON.parse(data.toString()));
+      catch (err) {
+        fs.unlink(filename + '.json', function(err){});
+      }
     }
 
     fs.readFile(filename, function(err, data) {

--- a/lib/storage/fs/index.js
+++ b/lib/storage/fs/index.js
@@ -25,7 +25,7 @@ p.fetch = function(options, originalPath, stepsHash, cb) {
       try {
         info = _.merge(info, JSON.parse(data.toString()));
       catch (err) {
-        fs.unlink(filename + '.json', function(err){});
+        cb(err);
       }
     }
 


### PR DESCRIPTION
I started to get the following error:

{"path":"frames/1514054709600","format":"webp","width":480,"height":270,"space":"srgb","channels":3,"density":96,"hasProfile":false,"hasAlpha":false,"hash":1600461126,"byteSize":1744,"author":"*.*.*.*","stepsHash":432247542}}                                                                                                                                                                                                                                                                                  
                                                                                                                                                  ^
SyntaxError: Unexpected token } in JSON at position 274
    at Object.parse (native)
    at /app/node_modules/image-steam/lib/storage/fs/index.js:25:33
    at /app/node_modules/graceful-fs/graceful-fs.js:78:16
    at tryToString (fs.js:455:3)
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:442:12)

It seems cached info data was with a extra curly brace for some unknown reason.

It was causing continuous application shutdown.

My sugestion it to add a try catch block around data parsing line that removes the cached data info if corrupted.

Aloha,

Rafael Sobral