### PR TITLE
keep orientation in image info

### DIFF
--- a/lib/processor/steps/rotate.js
+++ b/lib/processor/steps/rotate.js
@@ -42,7 +42,7 @@ module.exports = function(context, stepInfo) {
 
     // remove orientation now that it's been auto-corrected
     // to avoid downloaded asset from being rotated again
-    delete img.info.orientation;
+    // delete img.info.orientation;
   }
 
   switch (degrees) {


### PR DESCRIPTION
We need to keep the orientation in image info as if we remove it then the cached image never considers the orientation.