### PR TITLE
feat: adding support for google image service

### DIFF
--- a/lib/router/router-defaults.js
+++ b/lib/router/router-defaults.js
@@ -43,6 +43,9 @@ module.exports = {
     }
   },
   steps: {
+    gis : {
+      name: 'gcp-image-service'
+    },  
     rs: {
       name: 'resize',
       w: 'width',

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -182,7 +182,16 @@ function getImageStepsFromRoute(imageStepsStr) {
   return imageSteps.map(function(stepStr) {
     // format: crop=t:15,l:10,w:-10,h:-15
     const stepParts = stepStr.split($this.options.cmdValDelimiter);
-    const shortName = stepParts[0];
+    var shortName = stepParts[0];
+
+    // translate to support gcp image service.
+    if (shortName === "gis" && stepParts[1]) {
+      if (!( parseInt(stepParts[1].substr(1)) === 0 )) {
+        shortName = "rs"
+        const translatedParamValue = translateGISParams.call($this, stepParts[1])
+        stepParts[1] = translatedParamValue
+      }
+    }
 
     const cmdConfig = $this.options.commands[shortName];
     const stepConfig = cmdConfig ? null : $this.options.steps[shortName];
@@ -205,9 +214,6 @@ function getImageStepsFromRoute(imageStepsStr) {
       var paramParts = stepParam.split($this.options.paramValDelimiter);
       var paramName = paramParts[0];
       var fullParamName = config[paramName];
-      if (!fullParamName) {
-        throw new Error('Unsupported param ' + paramName + ' in step ' + stepStr);
-      }
       if (paramParts.length >= 2) {
         step[fullParamName] = paramParts[1];
       } else { // use a truthy value if key exists with no value
@@ -217,6 +223,27 @@ function getImageStepsFromRoute(imageStepsStr) {
 
     return step;
   });
+}
+
+// This function is used to translate a parameter from GIS to a supported format.
+function translateGISParams(parameter) {
+  var $this = this
+  if (parameter.startsWith('s')) {
+    var paramVal = parameter.substr(1)
+    var translatedParams = 'w' + $this.options.paramValDelimiter + paramVal + $this.options.paramKeyDelimiter + 'h' + $this.options.paramValDelimiter + paramVal
+    return translatedParams
+
+  } else if (parameter.startsWith('w')) {
+    var paramVal = parameter.substr(1)
+    var translatedParams = 'w' + $this.options.paramValDelimiter + paramVal
+    return translatedParams
+  } else if (parameter.startsWith('h')) {
+    var paramVal = parameter.substr(1)
+    var translatedParams = 'h' + $this.options.paramValDelimiter + paramVal
+    return translatedParams
+  } 
+
+  throw new Error('Google Image Service parameter is invalid: ' + parameter);
 }
 
 function flattenSteps(steps) {

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -225,7 +225,7 @@ function getImageStepsFromRoute(imageStepsStr) {
   });
 }
 
-// This function is used to translate a parameter from GIS to a supported format.
+// This function is used to translate an image step from gcp image service to a supported format.
 function translateGISParams(parameter) {
   var $this = this
   if (parameter.startsWith('s')) {

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -214,6 +214,9 @@ function getImageStepsFromRoute(imageStepsStr) {
       var paramParts = stepParam.split($this.options.paramValDelimiter);
       var paramName = paramParts[0];
       var fullParamName = config[paramName];
+      if (!fullParamName) {
+        throw new Error('Unsupported param ' + paramName + ' in step ' + stepStr);
+      }
       if (paramParts.length >= 2) {
         step[fullParamName] = paramParts[1];
       } else { // use a truthy value if key exists with no value


### PR DESCRIPTION
This PR adds support to the image steam service, so that if we send in parameters that are appended to the serving URL created by GCP Image service, it works. 
[Here](https://cloud.google.com/appengine/docs/standard/python/images#get-serving-url) is a link that shows how a serving URL is got from Google and then parameters are appended for image size modification.

This PR adds support for resizing the image according to Google Image service parameters, i.e `=sXX`(resize along the longer side), `=wXX`(resize along the width), `=hXX`(resize along the height).

After this PR is merged,

The following types of requests would be supported.

http://localhost:13337/Eiffel_Tower_Vertical.JPG/:/gis - This will return the default image.
http://localhost:13337/Eiffel_Tower_Vertical.JPG/:/gis=s0 - This will return the default image.
http://localhost:13337/Eiffel_Tower_Vertical.JPG/:/gis=s20 - This will constrain the longer side to 20
http://localhost:13337/Eiffel_Tower_Vertical.JPG/:/gis=w10 - This will constrain the width to 10.
http://localhost:13337/Eiffel_Tower_Vertical.JPG/:/gis=h10 - This will constrain the height side to 10.

This will be compatible with other parameters 

http://localhost:13337/Eiffel_Tower_Vertical.JPG/:/gis=h10/cr=l:50,t:50 - This will crop the image and constrain the height side to 10.

The only parameter this might not be compatible with is `rs`.

So clients should specify either rs or gis
If both are specified, the parameter that is later will be the one that will override the one that is before.

Also there is one implicit assumption that the cmdValDelimiter is `=` to work with the gcp image service.




