### PR TITLE
fix(ci): allows optional installs for Sharp binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --no-optional
+        run: npm ci
 
       - name: Test
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      IS_CI_ENV: '1'
     strategy:
       fail-fast: false
       matrix:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mocha": "mocha -w -R spec",
     "prettier": "npx prettier --write lib test",
     "report": "nyc report --reporter=cobertura && nyc report --reporter=lcov",
-    "test": "npm run prettier && npm run test-and-check && npm outdated",
+    "test": "npm run prettier && npm run test-and-check && (npm outdated || true)",
     "test-and-check": "npm run unit && npm run report && npm run check-cov",
     "unit": "npx nyc ./node_modules/mocha/bin/_mocha"
   },

--- a/test/image-server.requests.js
+++ b/test/image-server.requests.js
@@ -315,8 +315,8 @@ module.exports = [
   },
 ];
 
-if (process.env.TRAVIS === undefined) {
-  // not supported by travis CI
+if (process.env.IS_CI_ENV === undefined) {
+  // Some image formats/steps are slower or not supported in CI.
   module.exports = module.exports.concat([
     {
       steps: 'fm=f:avif',


### PR DESCRIPTION
Sorry—I should have run these GitHub Actions in a local environment before merging them in!

I noticed the new CI script failed. Using `--no-optional` is likely preventing Sharp from installing binaries—they are packages as optional dependencies for it, which may not have been the case before #100.